### PR TITLE
5.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ to run the bot use `npm run run`
 
 to run the docs use `npm run run-web` 
 
-to run both the bot and docs simultaneously use `npm run run-all`
+to run both the bot and docs simultaneously use `npm run run-full`
 
 
 ## required permissions

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ add the bot to an empty server and give it `create+manage expressions` permissio
 
 to compile the bot the bot use `tsc` or `npm run build`
 
-to run the compiled code use `npm run run` 
+to run the bot use `npm run run` 
 
-to run without docs use `npm run noweb` 
+to run the docs use `npm run run-web` 
+
+to run both the bot and docs simultaneously use `npm run run-all`
 
 
 ## required permissions

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 -   `MapParse` Submitted not being on a new line
 -   `MapParse` Mirror names
 -   `WhatIf` command not properly quitting if a null value is given
+-   `Simulate` DT/NC/HT/DC no longer multiplies `overrideSpeed`
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 -   `MapParse` Mirror names
 -   `WhatIf` command not properly quitting if a null value is given
 -   `Simulate` DT/NC/HT/DC no longer multiplies `overrideSpeed`
+-   `Simulate` custom speed from previous scores is ignored
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@
 
 ## [5.6.0] - 2025-12-18
 
+### Fixed
+
+-   `MapParse` Submitted not being on a new line
+
 [commit](https://github.com/sbrstrkkdwmdr/ssob/commit/d155867d7b780b5e5c3f8b41adea4afad62849bf)</br>
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -13,11 +13,13 @@
 -   `WhatIf` - command not properly quitting if a null value is given
 -   `Simulate` - DT/NC/HT/DC no longer multiplies `overrideSpeed`
 -   `Simulate` - custom speed from previous scores is ignored
+-   `MapParse` - ppcalc embed not being sent
 
 ### Changed
 
 -   (docs) small tweaks
 -   sendError() no longer throws an error (mostly just cluttered the console)
+-   only use `.toFixed()` on numbers that exceed 2 d.p.
 
 ## [5.6.0] - 2025-12-18
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 -   `MapParse` Submitted not being on a new line
+-   `MapParse` Mirror names
 
 [commit](https://github.com/sbrstrkkdwmdr/ssob/commit/d155867d7b780b5e5c3f8b41adea4afad62849bf)</br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,12 +6,16 @@
 
 [commit](https://github.com/sbrstrkkdwmdr/ssob)</br>
 
-## [5.6.0] - 2025-12-18
-
 ### Fixed
 
 -   `MapParse` Submitted not being on a new line
 -   `MapParse` Mirror names
+
+### Changed
+
+-   (docs) small tweaks
+
+## [5.6.0] - 2025-12-18
 
 [commit](https://github.com/sbrstrkkdwmdr/ssob/commit/d155867d7b780b5e5c3f8b41adea4afad62849bf)</br>
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@
 
 [commit](https://github.com/sbrstrkkdwmdr/ssob)</br>
 
+
+## [5.6.1] - 2026-01-25
+
+[commit](https://github.com/sbrstrkkdwmdr/ssob)</br>
+
 ### Fixed
 
 -   `MapParse` - Submitted not being on a new line

--- a/changelog.md
+++ b/changelog.md
@@ -19,9 +19,9 @@
 
 -   (docs) `ScoreListCommand` - missing star rating option for score sorting
 -   (docs) "Formatted as" being on the same line as arg description
--   (docs) `ScoreListCommand` - sort by default is now recent on some lists
+-   (docs) `ScoreListCommand` - fix default "sort by" value
 -   method `scoreIsComplete` returning incorrect percentage
--   `Recent` page buttons now disable based
+-   `Recent` page buttons now disable based on score position
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 
 ## [5.6.1] - 2026-01-25
 
-[commit](https://github.com/sbrstrkkdwmdr/ssob)</br>
+[commit](https://github.com/sbrstrkkdwmdr/ssob/commit/dad7ae402d15b3db88dd719646aebc6c4dd83bef)</br>
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 ### Changed
 
 -   (docs) small tweaks
+-   sendError() no longer throws an error (mostly just cluttered the console)
 
 ## [5.6.0] - 2025-12-18
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,11 +8,11 @@
 
 ### Fixed
 
--   `MapParse` Submitted not being on a new line
--   `MapParse` Mirror names
--   `WhatIf` command not properly quitting if a null value is given
--   `Simulate` DT/NC/HT/DC no longer multiplies `overrideSpeed`
--   `Simulate` custom speed from previous scores is ignored
+-   `MapParse` - Submitted not being on a new line
+-   `MapParse` - Mirror names
+-   `WhatIf` - command not properly quitting if a null value is given
+-   `Simulate` - DT/NC/HT/DC no longer multiplies `overrideSpeed`
+-   `Simulate` - custom speed from previous scores is ignored
 
 ### Changed
 
@@ -39,10 +39,10 @@
 -   `Simulate` - params equal to 0 are no longer treated as null
 -   `Simulate` - score statistics are no longer automatically taken from the most recent score (can be re-enabled with `-prev`)
 -   strain graphs are now filled line charts
--   `MapParse` now show both fail and exit times in detailed mode
--   `MapParse` update shown mirrors
--   `MapParse` difficulty rating in select menus rounds to 2 decimal places
--   `Recent`, `ScoreParse` strains graph highlights passed section for failed scores
+-   `MapParse` - now show both fail and exit times in detailed mode
+-   `MapParse` - update shown mirrors
+-   `MapParse` - difficulty rating in select menus rounds to 2 decimal places
+-   `Recent`, `ScoreParse` - strains graph highlights passed section for failed scores
 
 ### Refactor
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 
 -   `MapParse` Submitted not being on a new line
 -   `MapParse` Mirror names
+-   `WhatIf` command not properly quitting if a null value is given
 
 ### Changed
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -215,7 +215,7 @@ export class Command {
         this.voidcontent();
         this.ctn.content = err;
         await this.send();
-        throw new Error(err);
+        // throw new Error(err);
     }
     protected async sendLoading() {
         const temp = this.ctn;

--- a/src/commands/general/Changelog.ts
+++ b/src/commands/general/Changelog.ts
@@ -171,7 +171,7 @@ export class Changelog extends Command {
     }
     createEmbed() {
         const embed = new Discord.EmbedBuilder();
-        const doc = fs.readFileSync(`${helper.path.main}/cache/changelog.md`, 'utf-8');
+        const doc = fs.readFileSync(`${helper.path.cache}/changelog.md`, 'utf-8');
         const list = doc.split('## [');
         list.shift();
         if (typeof this.found == 'string') {

--- a/src/commands/osu_maps/MapParse.ts
+++ b/src/commands/osu_maps/MapParse.ts
@@ -996,8 +996,8 @@ function mirrors(setid: number, mapid: number) {
         'osu!': 'https://osu.ppy.sh/b/' + mapid,
         // 'Chimu': 'https://api.chimu.moe/v1/download/' + setid,
         'beatconnect.io': 'https://beatconnect.io/b/' + setid,
-        'kitsu.moe': 'https://kitsu.app/d/' + setid,
-        'nekoha.app': 'https://mirror.nekoha.moe/api4/download/' + setid,
+        'kitsu.app': 'https://kitsu.app/d/' + setid,
+        'nekoha.moe': 'https://mirror.nekoha.moe/api4/download/' + setid,
         'Preview (jmir)': 'https://osu-preview.jmir.xyz/preview#' + mapid,
         'Preview (try-z)': 'https://beatmap.try-z.net/?b=' + mapid,
     };

--- a/src/commands/osu_maps/MapParse.ts
+++ b/src/commands/osu_maps/MapParse.ts
@@ -951,6 +951,9 @@ ${ppComputed[0].ppFlashlight > 0 ? `\`Flashlight ${ppComputed[10].ppFlashlight?.
                     inline: true
                 }
             ]);
+        this.ctn.embeds = [embed];
+        embed.setColor(formatters.difficultyColour(+totaldiff).dec);
+
     }
     protected mapstats(map: osuapi.types_v2.BeatmapExtended, allvals, totaldiff: string) {
         return `CS${allvals.cs != map.cs ? `${map.cs}=>${allvals.cs}` : allvals.cs}

--- a/src/commands/osu_maps/MapParse.ts
+++ b/src/commands/osu_maps/MapParse.ts
@@ -826,7 +826,7 @@ export class MapParse extends OsuCommand {
         if (states.includes(map.status)) {
             last = `${formatters.toCapital(map.status)} <t:${Math.floor(new Date(mapset.ranked_date).getTime() / 1000)}:R>`;
         }
-        return formatters.listLine(submit, last);
+        return '\n' + formatters.listLine(submit, last);
     }
     protected async embedPerformance(embed: Discord.EmbedBuilder, map: osuapi.types_v2.BeatmapExtended, allvals, totaldiff: string, ppComputed: rosu.PerformanceAttributes[]) {
         let extras = '';

--- a/src/commands/osu_maps/MapParse.ts
+++ b/src/commands/osu_maps/MapParse.ts
@@ -398,7 +398,7 @@ export class MapParse extends OsuCommand {
                                     helper.emojis.gamemodes.standard
                         }` as Discord.APIMessageComponentEmoji)
                     .setLabel(`${this.map.version}`)
-                    .setDescription(`${this.map.difficulty_rating.toFixed(2)}⭐`)
+                    .setDescription(`${calculate.fixLongDecimal(this.map.difficulty_rating)}⭐`)
                     .setValue(`${this.map.id}`)
             );
         } else {
@@ -414,7 +414,7 @@ export class MapParse extends OsuCommand {
                                         helper.emojis.gamemodes.standard
                             }` as Discord.APIMessageComponentEmoji)
                         .setLabel(`${curmap.version}`)
-                        .setDescription(`${curmap.difficulty_rating.toFixed(2)}⭐`)
+                        .setDescription(`${calculate.fixLongDecimal(curmap.difficulty_rating)}⭐`)
                         .setValue(`${curmap.id}`)
                 );
             }
@@ -492,7 +492,7 @@ export class MapParse extends OsuCommand {
 
         let ppComputed: rosu.PerformanceAttributes[];
         let ppissue: string;
-        let totaldiff: string = map.difficulty_rating?.toFixed(2);
+        let totaldiff: string = calculate.fixLongDecimal(map.difficulty_rating) + '';
         try {
             ppComputed = await performance.calcMap({
                 mods: this.params.mapmods,
@@ -507,13 +507,11 @@ export class MapParse extends OsuCommand {
                 isLazer: true,
             });
             ppissue = '';
-            try {
-                totaldiff = map.difficulty_rating.toFixed(2) != ppComputed[0].difficulty.stars?.toFixed(2) ?
-                    `${map.difficulty_rating.toFixed(2)}=>${ppComputed[0].difficulty.stars?.toFixed(2)}` :
-                    `${map.difficulty_rating.toFixed(2)}`;
-            } catch (error) {
-                totaldiff = map.difficulty_rating?.toFixed(2);
-            }
+
+            totaldiff = map.difficulty_rating.toFixed(2) != ppComputed[0].difficulty.stars?.toFixed(2) ?
+                `${calculate.fixLongDecimal(map.difficulty_rating)}=>${calculate.fixLongDecimal(ppComputed[0].difficulty.stars)}` :
+                `${calculate.fixLongDecimal(map.difficulty_rating)}`;
+
             data.debug(ppComputed, this.name, this.input.message?.guildId ?? this.input.interaction?.guildId, 'ppCalc');
 
         } catch (error) {
@@ -528,21 +526,7 @@ export class MapParse extends OsuCommand {
                 ppissue += '\nInvalid mod combinations: DT/NC + HT';
             }
             const ppComputedTemp = performance.template(map);
-            ppComputed = [
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-                ppComputedTemp,
-            ];
+            ppComputed = other.repeatArray(ppComputedTemp, 13);
         }
         const mapname = formatters.parseUnicodeStrings({
             title: this.map.beatmapset.title,
@@ -670,7 +654,8 @@ export class MapParse extends OsuCommand {
             .setThumbnail(osuapi.other.beatmapImages(this.map.beatmapset_id).list2x)
             .setTitle(maptitle);
         embed.setColor(formatters.difficultyColour(+map.difficulty_rating).dec);
-        if (this.params.isppCalc) await this.embedPerformance(embed, map, allvals, totaldiff, ppComputed); else await this.embedMap(embed, map, allvals, totaldiff, ppComputed, buttons);
+        if (this.params.isppCalc) await this.embedPerformance(embed, map, allvals, totaldiff, ppComputed);
+        else await this.embedMap(embed, map, allvals, totaldiff, ppComputed, buttons);
     }
     protected async embedMap(embed: Discord.EmbedBuilder, map: osuapi.types_v2.BeatmapExtended, allvals, totaldiff: string, ppComputed: rosu.PerformanceAttributes[], buttons: Discord.ActionRowBuilder) {
         let mapgraph = await this.strainsGraph(map);
@@ -701,12 +686,12 @@ export class MapParse extends OsuCommand {
                 {
                     name: 'PP',
                     value:
-                        `SS: ${ppComputed[0].pp?.toFixed(2)} \n ` +
-                        `99: ${ppComputed[1].pp?.toFixed(2)} \n ` +
-                        `98: ${ppComputed[2].pp?.toFixed(2)} \n ` +
-                        `97: ${ppComputed[3].pp?.toFixed(2)} \n ` +
-                        `96: ${ppComputed[4].pp?.toFixed(2)} \n ` +
-                        `95: ${ppComputed[5].pp?.toFixed(2)} \n `
+                        `SS: ${calculate.fixLongDecimal(ppComputed[0].pp)} \n ` +
+                        `99: ${calculate.fixLongDecimal(ppComputed[1].pp)} \n ` +
+                        `98: ${calculate.fixLongDecimal(ppComputed[2].pp)} \n ` +
+                        `97: ${calculate.fixLongDecimal(ppComputed[3].pp)} \n ` +
+                        `96: ${calculate.fixLongDecimal(ppComputed[4].pp)} \n ` +
+                        `95: ${calculate.fixLongDecimal(ppComputed[5].pp)} \n `
                     ,
                     inline: this.params.detailed != 2
                 },
@@ -939,24 +924,24 @@ ${ppComputed[0].ppFlashlight > 0 ? `\`Flashlight ${ppComputed[10].ppFlashlight?.
                 {
                     name: 'PP',
                     value:
-                        `\`SS:    \` ${ppComputed[0].pp?.toFixed(2)} \n ` +
-                        `\`99%:   \` ${ppComputed[1].pp?.toFixed(2)} \n ` +
-                        `\`98%:   \` ${ppComputed[2].pp?.toFixed(2)} \n ` +
-                        `\`97%:   \` ${ppComputed[3].pp?.toFixed(2)} \n ` +
-                        `\`96%:   \` ${ppComputed[4].pp?.toFixed(2)} \n ` +
-                        `\`95%:   \` ${ppComputed[5].pp?.toFixed(2)} \n ` +
-                        `\`94%:   \` ${ppComputed[6].pp?.toFixed(2)} \n ` +
-                        `\`93%:   \` ${ppComputed[7].pp?.toFixed(2)} \n ` +
-                        `\`92%:   \` ${ppComputed[8].pp?.toFixed(2)} \n ` +
-                        `\`91%:   \` ${ppComputed[9].pp?.toFixed(2)} \n ` +
-                        `\`90%:   \` ${ppComputed[10].pp?.toFixed(2)} \n ` +
+                        `\`SS:    \` ${calculate.fixLongDecimal(ppComputed[0].pp)} \n ` +
+                        `\`99%:   \` ${calculate.fixLongDecimal(ppComputed[1].pp)} \n ` +
+                        `\`98%:   \` ${calculate.fixLongDecimal(ppComputed[2].pp)} \n ` +
+                        `\`97%:   \` ${calculate.fixLongDecimal(ppComputed[3].pp)} \n ` +
+                        `\`96%:   \` ${calculate.fixLongDecimal(ppComputed[4].pp)} \n ` +
+                        `\`95%:   \` ${calculate.fixLongDecimal(ppComputed[5].pp)} \n ` +
+                        `\`94%:   \` ${calculate.fixLongDecimal(ppComputed[6].pp)} \n ` +
+                        `\`93%:   \` ${calculate.fixLongDecimal(ppComputed[7].pp)} \n ` +
+                        `\`92%:   \` ${calculate.fixLongDecimal(ppComputed[8].pp)} \n ` +
+                        `\`91%:   \` ${calculate.fixLongDecimal(ppComputed[9].pp)} \n ` +
+                        `\`90%:   \` ${calculate.fixLongDecimal(ppComputed[10].pp)} \n ` +
                         `---===MODDED===---\n` +
-                        `\`HD:    \` ${(await this.perf(['HD'], map)).pp?.toFixed(2)} \n ` +
-                        `\`HR:    \` ${(await this.perf(['HR'], map)).pp?.toFixed(2)} \n ` +
-                        `\`DT:    \` ${(await this.perf(['DT'], map)).pp?.toFixed(2)} \n ` +
-                        `\`HDHR:  \` ${(await this.perf(['HD', 'HR'], map)).pp?.toFixed(2)} \n ` +
-                        `\`HDDT:  \` ${(await this.perf(['HD', 'DT'], map)).pp?.toFixed(2)} \n ` +
-                        `\`HDDTHR:\` ${(await this.perf(['HD', 'DT', 'HR'], map)).pp?.toFixed(2)} \n `
+                        `\`HD:    \` ${calculate.fixLongDecimal((await this.perf(['HD'], map)).pp)} \n ` +
+                        `\`HR:    \` ${calculate.fixLongDecimal((await this.perf(['HR'], map)).pp)} \n ` +
+                        `\`DT:    \` ${calculate.fixLongDecimal((await this.perf(['DT'], map)).pp)} \n ` +
+                        `\`HDHR:  \` ${calculate.fixLongDecimal((await this.perf(['HD', 'HR'], map)).pp)} \n ` +
+                        `\`HDDT:  \` ${calculate.fixLongDecimal((await this.perf(['HD', 'DT'], map)).pp)} \n ` +
+                        `\`HDDTHR:\` ${calculate.fixLongDecimal((await this.perf(['HD', 'DT', 'HR'], map)).pp)} \n `
                     ,
                     inline: true
                 },

--- a/src/commands/osu_maps/RecommendMap.ts
+++ b/src/commands/osu_maps/RecommendMap.ts
@@ -1,6 +1,7 @@
 import Discord from 'discord.js';
 import * as osumodcalc from 'osumodcalculator';
 import * as helper from '../../helper';
+import { fixLongDecimal } from '../../tools/calculate';
 import * as data from '../../tools/data';
 import * as osuapi from '../../tools/osuapi';
 import { OsuCommand } from '../command';
@@ -68,10 +69,10 @@ export class RecommendMap extends OsuCommand {
             }
         }
 
-        const randomMap = data.recommendMap(+(osumodcalc.extra.recdiff(osudata.statistics.pp)).toFixed(2), this.params.useType, this.params.mode, this.params.maxRange ?? 1);
+        const randomMap = data.recommendMap(fixLongDecimal(osumodcalc.extra.recdiff(osudata.statistics.pp)), this.params.useType, this.params.mode, this.params.maxRange ?? 1);
         const exTxt =
             this.params.useType == 'closest' ? '' :
-                `Random map within ${this.params.maxRange}⭐ of ${(osumodcalc.extra.recdiff(osudata.statistics.pp))?.toFixed(2)}
+                `Random map within ${this.params.maxRange}⭐ of ${fixLongDecimal(osumodcalc.extra.recdiff(osudata.statistics.pp))}
     Pool of ${randomMap.poolSize}
     `;
 

--- a/src/commands/osu_other/Compare.ts
+++ b/src/commands/osu_other/Compare.ts
@@ -225,7 +225,7 @@ export class Compare extends OsuCommand {
                         value:
                             `**Rank:** ${calculate.separateNum(firstuser?.statistics.global_rank)}
 **pp:** ${calculate.separateNum(firstuser?.statistics.pp)}
-**Accuracy:** ${(firstuser?.statistics.hit_accuracy != null ? firstuser.statistics.hit_accuracy : 0).toFixed(2)}%
+**Accuracy:** ${calculate.fixLongDecimal(firstuser?.statistics.hit_accuracy != null ? firstuser.statistics.hit_accuracy : 0)}%
 **Playcount:** ${calculate.separateNum(firstuser?.statistics.play_count)}
 **Level:** ${calculate.separateNum(firstuser.statistics.level.current)}
 `,
@@ -236,7 +236,7 @@ export class Compare extends OsuCommand {
                         value:
                             `**Rank:** ${calculate.separateNum(seconduser?.statistics.global_rank)}
 **pp:** ${calculate.separateNum(seconduser?.statistics.pp)}
-**Accuracy:** ${(seconduser?.statistics.hit_accuracy != null ? seconduser.statistics.hit_accuracy : 0).toFixed(2)}%
+**Accuracy:** ${calculate.fixLongDecimal(seconduser?.statistics.hit_accuracy != null ? seconduser.statistics.hit_accuracy : 0)}%
 **Playcount:** ${calculate.separateNum(seconduser?.statistics.play_count)}
 **Level:** ${calculate.separateNum(seconduser.statistics.level.current)}
 `,
@@ -246,8 +246,8 @@ export class Compare extends OsuCommand {
                         name: `**Difference**`,
                         value:
                             `**Rank:** ${calculate.separateNum(Math.abs(firstuser.statistics.global_rank - seconduser.statistics.global_rank))}
-**pp:** ${calculate.separateNum(Math.abs(firstuser?.statistics.pp - seconduser?.statistics.pp).toFixed(2))}
-**Accuracy:** ${Math.abs((firstuser.statistics.hit_accuracy != null ? firstuser.statistics.hit_accuracy : 0) - (seconduser.statistics.hit_accuracy != null ? seconduser.statistics.hit_accuracy : 0)).toFixed(2)}%
+**pp:** ${calculate.separateNum(calculate.fixLongDecimal(Math.abs(firstuser?.statistics.pp - seconduser?.statistics.pp)))}
+**Accuracy:** ${calculate.fixLongDecimal(Math.abs((firstuser.statistics.hit_accuracy != null ? firstuser.statistics.hit_accuracy : 0) - (seconduser.statistics.hit_accuracy != null ? seconduser.statistics.hit_accuracy : 0)))}%
 **Playcount:** ${calculate.separateNum(Math.abs(firstuser.statistics.play_count - seconduser.statistics.play_count))}
 **Level:** ${calculate.separateNum(Math.abs(firstuser.statistics.level.current - seconduser.statistics.level.current))}
 `,
@@ -284,7 +284,7 @@ export class Compare extends OsuCommand {
             const secondscore: osuapi.types_v2.Score = secondtopdata.find(score => score.beatmap.id == firstscore.beatmap.id);
             if (secondscore == null) break;
             const format = (score: osuapi.types_v2.Score) =>
-                `${score.pp.toFixed(2)}pp | ${(score.accuracy * 100).toFixed(2)}% ${score.mods.length > 0 ? '| +' + score.mods.map(x => x.acronym).join('') : ''}`;
+                `${calculate.fixLongDecimal(score.pp)}pp | ${calculate.fixLongDecimal(score.accuracy * 100)}% ${score.mods.length > 0 ? '| +' + score.mods.map(x => x.acronym).join('') : ''}`;
             const firstscorestr = format(firstscore);
             const secondscorestr = format(secondscore);
             arrscore.push(

--- a/src/commands/osu_other/RankPP.ts
+++ b/src/commands/osu_other/RankPP.ts
@@ -61,7 +61,7 @@ export class RankPP extends OsuCommand {
                 break;
             case 'rank': {
                 returnval = await data.getRankPerformance('rank->pp', this.params.value, this.params.mode);
-                output = 'approx. ' + calculate.separateNum(returnval.value.toFixed(2)) + 'pp';
+                output = 'approx. ' + calculate.separateNum(calculate.fixLongDecimal(returnval.value)) + 'pp';
 
                 Embed
                     .setTitle(`Approximate performance for rank #${this.params.value}`);

--- a/src/commands/osu_other/ServerLeaderboard.ts
+++ b/src/commands/osu_other/ServerLeaderboard.ts
@@ -1,5 +1,6 @@
 import Discord from 'discord.js';
 import * as helper from '../../helper';
+import { fixLongDecimal } from '../../tools/calculate';
 import * as commandTools from '../../tools/commands';
 import * as osuapi from '../../tools/osuapi';
 import { OsuCommand } from '../command';
@@ -123,7 +124,7 @@ export class ServerLeaderboard extends OsuCommand {
                     : 4
                 : 5;
             const user = helper.vars.client.users.cache.get(cur.discord);
-            rtxt += `\n#${i + 1 + pageOffset + ')'.padEnd(pad, ' ')} ${this.overlengthString(user.username, 14)} ${this.overlengthString(cur.name, 14)} ${(cur.rank + '').padEnd(10)} ${(cur.acc.toFixed(2) + '%').padEnd(8)} ${cur.pp}pp`;
+            rtxt += `\n#${i + 1 + pageOffset + ')'.padEnd(pad, ' ')} ${this.overlengthString(user.username, 14)} ${this.overlengthString(cur.name, 14)} ${(cur.rank + '').padEnd(10)} ${(fixLongDecimal(cur.acc) + '%').padEnd(8)} ${cur.pp}pp`;
         }
 
         rtxt += `\n\``;

--- a/src/commands/osu_other/WhatIf.ts
+++ b/src/commands/osu_other/WhatIf.ts
@@ -61,7 +61,8 @@ export class WhatIf extends OsuCommand {
         // do stuff
 
         if (!this.params.pp || isNaN(this.params.pp) || this.params.pp > 10000) {
-            this.input.message.reply("Please define a valid PP value to calculate");
+            await this.sendError(`Please define a valid PP value to calculate`);
+            return;
         }
 
         await this.fixUser();
@@ -88,8 +89,7 @@ export class WhatIf extends OsuCommand {
         try {
             osutopdata = await this.getTopData(osudata.id, this.params.mode);
         } catch (e) {
-            this.ctn.content = 'There was an error trying to fetch top scores';
-            await this.send();
+            await this.sendError(`Could not fetch user\'s top scores`);
             return;
         }
 

--- a/src/commands/osu_other/WhatIf.ts
+++ b/src/commands/osu_other/WhatIf.ts
@@ -123,8 +123,8 @@ export class WhatIf extends OsuCommand {
     `);
         } else {
             embed.setDescription(
-                `A ${this.params.pp}pp score would be their **${calculate.toOrdinal(ppindex + 1)}** top play and would be weighted at **${(weight * 100).toFixed(2)}%**.
-    Their pp would change by **${Math.abs((total + bonus) - osudata.statistics.pp).toFixed(2)}pp** and their new total pp would be **${(total + bonus).toFixed(2)}pp**.
+                `A ${this.params.pp}pp score would be their **${calculate.toOrdinal(ppindex + 1)}** top play and would be weighted at **${calculate.fixLongDecimal(weight * 100)}%**.
+    Their pp would change by **${calculate.fixLongDecimal(Math.abs((total + bonus) - osudata.statistics.pp))}pp** and their new total pp would be **${calculate.fixLongDecimal(total + bonus)}pp**.
     Their new rank would be **${Math.round(guessrank.value)}** (+${Math.round(osudata?.statistics?.global_rank - guessrank.value)}).
     `
             );

--- a/src/commands/osu_profiles/Badges.ts
+++ b/src/commands/osu_profiles/Badges.ts
@@ -46,9 +46,6 @@ export class Badges extends OsuCommand {
             const t = await this.getProfile(this.params.user, 'osu');
             osudata = t;
         } catch (e) {
-            console.log(this.params.user);
-            console.log(this.params.searchid);
-            console.log(e);
             return;
         }
         console.log('continue');

--- a/src/commands/osu_profiles/Profile.ts
+++ b/src/commands/osu_profiles/Profile.ts
@@ -219,8 +219,8 @@ ${this.gradeCounts}
 ${this.previousNames}
 ${this.supporterStatus} ${this.onlineStatus}
 **Avg time per play:** ${this.timePerPlay}
-**Avg daily playcount:** ${this.dailyPlaycount.toFixed(2)}
-**Avg monthly playcount:** ${this.monthlyPlaycount.toFixed(2)}
+**Avg daily playcount:** ${calculate.fixLongDecimal(this.dailyPlaycount)}
+**Avg monthly playcount:** ${calculate.fixLongDecimal(this.monthlyPlaycount)}
 `,
                 inline: true
             }
@@ -254,7 +254,7 @@ ${this.supporterStatus} ${this.onlineStatus}
     }
     protected get statAccuracy() {
         if (this.user.statistics.hit_accuracy) {
-            return this.user.statistics.hit_accuracy.toFixed(2);
+            return calculate.fixLongDecimal(this.user.statistics.hit_accuracy);
         }
         return '00.00';
     }

--- a/src/commands/osu_profiles/Ranking.ts
+++ b/src/commands/osu_profiles/Ranking.ts
@@ -267,7 +267,7 @@ Total PP: ${calculate.numberShorthand(country.performance)}
                         value:
                             `:flag_${user.user.country_code.toLowerCase()}: [${user.user.username}](https://osu.ppy.sh/users/${user.user.id}/${this.params.mode})
 Score: ${user.total_score == null ? '---' : calculate.numberShorthand(user.total_score)} (${user.ranked_score == null ? '---' : calculate.numberShorthand(user.ranked_score)} ranked)
-${user.hit_accuracy == null ? '---' : user.hit_accuracy.toFixed(2)}% | ${user.pp == null ? '---' : calculate.separateNum(user.pp)}pp | ${user.play_count == null ? '---' : calculate.separateNum(user.play_count)} plays
+${user.hit_accuracy == null ? '---' : calculate.fixLongDecimal(user.hit_accuracy)}% | ${user.pp == null ? '---' : calculate.separateNum(user.pp)}pp | ${user.play_count == null ? '---' : calculate.separateNum(user.play_count)} plays
 `
                         ,
                         inline: false

--- a/src/commands/osu_scores/ReplayParse.ts
+++ b/src/commands/osu_scores/ReplayParse.ts
@@ -35,7 +35,6 @@ export class ReplayParse extends SingleScoreCommand {
         try {
             this.map = await this.getMap(score?.info?.beatmapHashMD5);
         } catch (e) {
-            console.log(e);
             return;
         }
 

--- a/src/commands/osu_scores/ScoreListCommand.ts
+++ b/src/commands/osu_scores/ScoreListCommand.ts
@@ -580,7 +580,7 @@ export class ScoreListCommand extends OsuCommand {
         const json = embed.toJSON();
         const temp = json.author!.name.split('|');
         temp.pop();
-        temp.push(` est. ${pp.toFixed(2)}pp (excl. bonus)`);
+        temp.push(` est. ${calculate.fixLongDecimal(pp)}pp (excl. bonus)`);
         embed.setAuthor({
             url: json.author.url,
             iconURL: json.author.icon_url,

--- a/src/commands/osu_scores/ScoreStats.ts
+++ b/src/commands/osu_scores/ScoreStats.ts
@@ -263,17 +263,17 @@ export class ScoreStats extends OsuCommand {
             diff: calculate.weightPerformance(calculations.map(x => x.ppDifficulty)).reduce((a, b) => a + b, 0),
             speed: calculate.weightPerformance(calculations.map(x => x.ppSpeed)).reduce((a, b) => a + b, 0),
         };
-        let totpp = `Total: ${ppcalc.total.toFixed(2)}`;
-        ppcalc.acc ? totpp += `\nAccuracy: ${ppcalc.acc.toFixed(2)}` : '';
-        ppcalc.aim ? totpp += `\nAim: ${ppcalc.aim.toFixed(2)}` : '';
-        ppcalc.diff ? totpp += `\nDifficulty: ${ppcalc.diff.toFixed(2)}` : '';
-        ppcalc.speed ? totpp += `\nSpeed: ${ppcalc.speed.toFixed(2)}` : '';
+        let totpp = `Total: ${calculate.fixLongDecimal(ppcalc.total)}`;
+        ppcalc.acc ? totpp += `\nAccuracy: ${calculate.fixLongDecimal(ppcalc.acc)}` : '';
+        ppcalc.aim ? totpp += `\nAim: ${calculate.fixLongDecimal(ppcalc.aim)}` : '';
+        ppcalc.diff ? totpp += `\nDifficulty: ${calculate.fixLongDecimal(ppcalc.diff)}` : '';
+        ppcalc.speed ? totpp += `\nSpeed: ${calculate.fixLongDecimal(ppcalc.speed)}` : '';
 
-        let weighttotpp = `Total: ${weightppcalc.total.toFixed(2)}`;
-        ppcalc.acc ? weighttotpp += `\nAccuracy: ${weightppcalc.acc.toFixed(2)}` : '';
-        ppcalc.aim ? weighttotpp += `\nAim: ${weightppcalc.aim.toFixed(2)}` : '';
-        ppcalc.diff ? weighttotpp += `\nDifficulty: ${weightppcalc.diff.toFixed(2)}` : '';
-        ppcalc.speed ? weighttotpp += `\nSpeed: ${weightppcalc.speed.toFixed(2)}` : '';
+        let weighttotpp = `Total: ${calculate.fixLongDecimal(weightppcalc.total)}`;
+        ppcalc.acc ? weighttotpp += `\nAccuracy: ${calculate.fixLongDecimal(weightppcalc.acc)}` : '';
+        ppcalc.aim ? weighttotpp += `\nAim: ${calculate.fixLongDecimal(weightppcalc.aim)}` : '';
+        ppcalc.diff ? weighttotpp += `\nDifficulty: ${calculate.fixLongDecimal(weightppcalc.diff)}` : '';
+        ppcalc.speed ? weighttotpp += `\nSpeed: ${calculate.fixLongDecimal(weightppcalc.speed)}` : '';
         return {
             pp, totpp, weighttotpp
         };
@@ -330,10 +330,10 @@ export class ScoreStats extends OsuCommand {
         return {
             name,
             value: `
-Highest: ${stat?.highest?.toFixed(2)}${suffix}
-Lowest: ${stat?.lowest?.toFixed(2)}${suffix}
-Average: ${stat?.mean?.toFixed(2)}${suffix}
-Median: ${stat?.median?.toFixed(2)}${suffix}
+Highest: ${calculate.fixLongDecimal(stat?.highest)}${suffix}
+Lowest: ${calculate.fixLongDecimal(stat?.lowest)}${suffix}
+Average: ${calculate.fixLongDecimal(stat?.mean)}${suffix}
+Median: ${calculate.fixLongDecimal(stat?.median)}${suffix}
 ${stat?.ignored > 0 ? `Skipped: ${stat?.ignored}` : ''}
 `,
             inline: true

--- a/src/commands/osu_scores/Simulate.ts
+++ b/src/commands/osu_scores/Simulate.ts
@@ -216,7 +216,7 @@ export class Simulate extends OsuCommand {
     }
     fixSpeedParams() {
         if (this.params.overrideBpm && !this.params.overrideSpeed) {
-            console.log(this.params.overrideBpm / this.map.bpm);
+            this.params.overrideSpeed = this.params.overrideBpm / this.map.bpm;
         }
         if (this.params.overrideSpeed && !this.params.overrideBpm) {
             this.params.overrideBpm = this.params.overrideSpeed * this.map.bpm;
@@ -260,7 +260,7 @@ export class Simulate extends OsuCommand {
     ${this.params.combo ?? this.map.max_combo}x/**${this.map.max_combo}**x
     ${this.params.mods && this.params.mods.length > 0 ? this.params.mods.join('') : 'NM'}
     \`${this.params.n300}/${this.params.n100}/${this.params.n50}/${this.params.nMiss}\`
-    Speed: ${this.params.overrideSpeed ?? 1}x @ ${this.params.overrideBpm ?? this.map.bpm}BPM
+    Speed: ${calculate.fixLongDecimal(this.params.overrideSpeed ?? 1)}x @ ${calculate.fixLongDecimal(this.params.overrideBpm ?? this.map.bpm)}BPM
     `,
                     inline: false
                 },

--- a/src/commands/osu_scores/Simulate.ts
+++ b/src/commands/osu_scores/Simulate.ts
@@ -210,20 +210,19 @@ export class Simulate extends OsuCommand {
     }
     fixSpeedParams() {
         if (this.params.overrideBpm && !this.params.overrideSpeed) {
-            this.params.overrideSpeed = this.params.overrideBpm / this.map.bpm;
+            console.log(this.params.overrideBpm / this.map.bpm)
         }
         if (this.params.overrideSpeed && !this.params.overrideBpm) {
             this.params.overrideBpm = this.params.overrideSpeed * this.map.bpm;
         }
-
-        if (this.params?.mods?.includes('DT') || this.params?.mods?.includes('NC')) {
-            this.params.overrideSpeed *= 1.5;
-            this.params.overrideBpm *= 1.5;
-        }
-        if (this.params?.mods?.includes('HT') || this.params?.mods?.includes('DC')) {
-            this.params.overrideSpeed *= 0.75;
-            this.params.overrideBpm *= 1.5;
-        }
+        // if (this.params?.mods?.includes('DT') || this.params?.mods?.includes('NC')) {
+        //     this.params.overrideSpeed *= 1.5;
+        //     this.params.overrideBpm *= 1.5;
+        // }
+        // if (this.params?.mods?.includes('HT') || this.params?.mods?.includes('DC')) {
+        //     this.params.overrideSpeed *= 0.75;
+        //     this.params.overrideBpm *= 1.5;
+        // }
     }
 
     fixAcc() {

--- a/src/commands/osu_scores/Simulate.ts
+++ b/src/commands/osu_scores/Simulate.ts
@@ -205,12 +205,18 @@ export class Simulate extends OsuCommand {
             if (!this.isValidParam(this.params.mods)) {
                 this.params.mods = tempscore.apiData.mods.map(x => x.acronym) as osumodcalc.types.Mod[] ?? [];
             }
+            if (!this.isValidParam(this.params.overrideSpeed) && !this.isValidParam(this.params.overrideBpm)) {
+                const overs = calculate.modOverrides(tempscore.apiData.mods);
+                if (overs.speed) {
+                    this.params.overrideSpeed = overs.speed;
+                }
+            }
         }
         return tempscore;
     }
     fixSpeedParams() {
         if (this.params.overrideBpm && !this.params.overrideSpeed) {
-            console.log(this.params.overrideBpm / this.map.bpm)
+            console.log(this.params.overrideBpm / this.map.bpm);
         }
         if (this.params.overrideSpeed && !this.params.overrideBpm) {
             this.params.overrideBpm = this.params.overrideSpeed * this.map.bpm;

--- a/src/commands/osu_scores/Simulate.ts
+++ b/src/commands/osu_scores/Simulate.ts
@@ -256,7 +256,7 @@ export class Simulate extends OsuCommand {
                 {
                     name: 'Score Details',
                     value:
-                        `${(useAcc)?.toFixed(2)}% | ${this.params.nMiss ?? 0}x misses
+                        `${calculate.fixLongDecimal(useAcc)}% | ${this.params.nMiss ?? 0}x misses
     ${this.params.combo ?? this.map.max_combo}x/**${this.map.max_combo}**x
     ${this.params.mods && this.params.mods.length > 0 ? this.params.mods.join('') : 'NM'}
     \`${this.params.n300}/${this.params.n100}/${this.params.n50}/${this.params.nMiss}\`
@@ -268,13 +268,13 @@ export class Simulate extends OsuCommand {
                     name: 'Performance',
                     value:
                         `
-${perfs[0].pp?.toFixed(2)}pp | ${perfs[1].pp?.toFixed(2)}pp if ${(useAcc)?.toFixed(2)}% FC
-SS: ${mapPerf[0].pp?.toFixed(2)}
-99: ${mapPerf[1].pp?.toFixed(2)}
-98: ${mapPerf[2].pp?.toFixed(2)}
-97: ${mapPerf[3].pp?.toFixed(2)}
-96: ${mapPerf[4].pp?.toFixed(2)}
-95: ${mapPerf[5].pp?.toFixed(2)} 
+${calculate.fixLongDecimal(perfs[0].pp)}pp | ${(calculate.fixLongDecimal) }pp if ${calculate.fixLongDecimal(useAcc) }% FC
+SS: ${calculate.fixLongDecimal(mapPerf[0].pp)}
+99: ${calculate.fixLongDecimal(mapPerf[1].pp)}
+98: ${calculate.fixLongDecimal(mapPerf[2].pp)}
+97: ${calculate.fixLongDecimal(mapPerf[3].pp)}
+96: ${calculate.fixLongDecimal(mapPerf[4].pp)}
+95: ${calculate.fixLongDecimal(mapPerf[5].pp)} 
 `
                 },
                 {
@@ -297,7 +297,7 @@ ${helper.emojis.mapobjs.circle}${this.map.count_circles}
 ${helper.emojis.mapobjs.slider}${this.map.count_sliders}
 ${helper.emojis.mapobjs.spinner}${this.map.count_spinners}
 ${helper.emojis.mapobjs.bpm}${this.map.bpm}
-${helper.emojis.mapobjs.star}${(perfs[0]?.difficulty?.stars ?? this.map.difficulty_rating)?.toFixed(2)}
+${helper.emojis.mapobjs.star}${calculate.fixLongDecimal(perfs[0]?.difficulty?.stars ?? this.map.difficulty_rating)}
 `,
                     inline: true
                 },

--- a/src/commands/osu_scores/SingleScoreCommand.ts
+++ b/src/commands/osu_scores/SingleScoreCommand.ts
@@ -53,7 +53,7 @@ export class SingleScoreCommand extends OsuCommand {
 
         let rsgrade = helper.emojis.grades[this.score.rank.toUpperCase()];
         if (!this.score.passed) {
-            rspassinfo = `${guesspasspercentage.toFixed(2)}% completed (${calculate.secondsToTime(curbmpasstime)}/${calculate.secondsToTime(this.map.total_length)})`;
+            rspassinfo = `${calculate.fixLongDecimal(guesspasspercentage)}% completed (${calculate.secondsToTime(curbmpasstime)}/${calculate.secondsToTime(this.map.total_length)})`;
             rsgrade = helper.emojis.grades.F + `(${helper.emojis.grades[this.grade().rank.toUpperCase()]} if pass)`;
         }
 
@@ -120,12 +120,12 @@ export class SingleScoreCommand extends OsuCommand {
             const mxCombo = perfs[0]?.difficulty?.maxCombo ?? this.map?.max_combo;
 
             if (this.score.accuracy < 1 && this.score.max_combo == mxCombo) {
-                fcflag = `FC\n**${perfs[2].pp.toFixed(2)}**pp IF SS`;
+                fcflag = `FC\n**${calculate.fixLongDecimal(perfs[2].pp)}**pp IF SS`;
             }
             if (this.score.max_combo != mxCombo) {
                 fcflag =
-                    `\n**${perfs[1].pp.toFixed(2)}**pp IF FC
-                **${perfs[2].pp.toFixed(2)}**pp IF SS`;
+                    `\n**${calculate.fixLongDecimal(perfs[1].pp)}**pp IF FC
+                **${calculate.fixLongDecimal(perfs[2].pp)}**pp IF SS`;
             }
             if (this.score.max_combo == mxCombo && this.score.accuracy == 1) {
                 fcflag = 'FC';
@@ -250,7 +250,7 @@ export class SingleScoreCommand extends OsuCommand {
                 {
                     name: 'SCORE DETAILS',
                     value: `${calculate.separateNum(other.getTotalScore(this.score))} ${scorerank}
-${(this.score.accuracy * 100).toFixed(2)}% | ${rsgrade}
+${calculate.fixLongDecimal(this.score.accuracy * 100)}% | ${rsgrade}
 ${this.score.has_replay ? `[REPLAY](https://osu.ppy.sh/scores/${this.score.id}/download)\n` : ''}` +
                         `${rspassinfo.length > 1 ? rspassinfo + '\n' : ''}${hitlist}
 ${this.score.max_combo == mxcombo ? `**${this.score.max_combo}x**` : `${this.score.max_combo}x`}/**${mxcombo}x** combo`,
@@ -258,7 +258,7 @@ ${this.score.max_combo == mxcombo ? `**${this.score.max_combo}x**` : `${this.sco
                 },
                 {
                     name: 'PP',
-                    value: `**${(this.score?.pp ?? perfs[0]?.pp ?? 0)?.toFixed(2)}**pp ${fcflag}\n${ppissue}`,
+                    value: `**${calculate.fixLongDecimal(this.score?.pp ?? perfs[0]?.pp ?? 0)}**pp ${fcflag}\n${ppissue}`,
                     inline: true
                 }
             ]);
@@ -266,16 +266,16 @@ ${this.score.max_combo == mxcombo ? `**${this.score.max_combo}x**` : `${this.sco
             case 'default':
                 embed.setTitle(fulltitle)
                     .setDescription(`${this.score.mods.length > 0 ? '+' + osumodcalc.mod.order(this.score.mods.map(x => x.acronym.toUpperCase()) as osumodcalc.types.Mod[]).join('') + modadjustments + ' |' : ''} ${formatters.relativeTime(this.score.ended_at)}
-    ${(perfs[0]?.difficulty?.stars ?? this.map?.difficulty_rating ?? 0).toFixed(2)}⭐ | ${helper.emojis.gamemodes[this.score.ruleset_id]}
-    `);
+${calculate.fixLongDecimal(perfs[0]?.difficulty?.stars ?? this.map?.difficulty_rating ?? 0)}⭐ | ${helper.emojis.gamemodes[this.score.ruleset_id]}
+`);
                 formatters.userAuthor(this.osudata, embed, this.params.overrideAuthor);
                 break;
             case 'recent':
                 embed.setTitle(`#${this.params.page + 1} most recent ${this.params.showFails == 1 ? 'play' : 'pass'} for ${this.score.user.username} | ${formatters.relativeTime(this.score.ended_at)}`)
                     .setDescription(`[\`${fulltitle}\`](https://osu.ppy.sh/b/${this.map.id}) ${this.score.mods.length > 0 ? '+' + osumodcalc.mod.order(this.score.mods.map(x => x.acronym.toUpperCase()) as osumodcalc.types.Mod[]).join('') + modadjustments : ''} 
-    ${(perfs[0]?.difficulty?.stars ?? this.map?.difficulty_rating ?? 0).toFixed(2)}⭐ | ${helper.emojis.gamemodes[this.score.ruleset_id]}
-    ${formatters.dateToDiscordFormat(new Date(this.score.ended_at), 'F')}
-    `);
+${calculate.fixLongDecimal(perfs[0]?.difficulty?.stars ?? this.map?.difficulty_rating ?? 0)}⭐ | ${helper.emojis.gamemodes[this.score.ruleset_id]}
+${formatters.dateToDiscordFormat(new Date(this.score.ended_at), 'F')}
+`);
 
                 break;
         }

--- a/src/loops.ts
+++ b/src/loops.ts
@@ -210,6 +210,7 @@ function clearMapFiles() {
 
 // other
 async function getOnlineChangelog() {
+    log.stdout('Fetching changelog from github...')
     await axios.get(`https://raw.githubusercontent.com/sbrstrkkdwmdr/ssob/dev/changelog.md`)
         .then(data => {
             fs.writeFileSync(`${helper.path.cache}/changelog.md`, data.data);

--- a/src/loops.ts
+++ b/src/loops.ts
@@ -4,6 +4,7 @@ import Discord from 'discord.js';
 import fs from 'fs';
 import v8 from 'v8';
 import * as helper from './helper';
+import { fixLongDecimal } from './tools/calculate';
 import * as log from './tools/log';
 import * as osuapi from './tools/osuapi';
 import * as track from './tools/track';
@@ -62,7 +63,7 @@ export function heapLoop() {
 
 function checkHeap() {
     const sl = v8.getHeapStatistics();
-    log.stdout(toMiB(sl.used_heap_size).toFixed(2) + 'MiB / ' + toMiB(sl.heap_size_limit) + 'MiB Heap Used');
+    log.stdout(fixLongDecimal(toMiB(sl.used_heap_size)) + 'MiB / ' + toMiB(sl.heap_size_limit) + 'MiB Heap Used');
 }
 
 function toMiB(number: number) {

--- a/src/tools/calculate.ts
+++ b/src/tools/calculate.ts
@@ -476,3 +476,9 @@ export function modOverrides(mods: osuapi.types_v2.Mod[]) {
     };
 
 }
+
+export function fixLongDecimal(n: number, maxDecimal: number = 2) {
+    if (n == Math.floor(n)) return n;
+    if (n * 10 == Math.floor(n * 10)) return n;
+    return +n.toFixed(maxDecimal);
+}

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -261,8 +261,8 @@ export type params = {
 };
 
 export function getButtonArgs(commandId: string | number) {
-    if (fs.existsSync(`${helper.path.main}/cache/params/${commandId}.json`)) {
-        const x = fs.readFileSync(`${helper.path.main}/cache/params/${commandId}.json`, 'utf-8');
+    if (fs.existsSync(`${helper.path.cache}/params/${commandId}.json`)) {
+        const x = fs.readFileSync(`${helper.path.cache}/params/${commandId}.json`, 'utf-8');
         return JSON.parse(x) as params;
     }
     return {
@@ -274,7 +274,7 @@ export function storeButtonArgs(commandId: string | number, params: params) {
     if (params?.page < 1) {
         params.page = 1;
     }
-    fs.writeFileSync(`${helper.path.main}/cache/params/${commandId}.json`, JSON.stringify(params, null, 2));
+    fs.writeFileSync(`${helper.path.cache}/params/${commandId}.json`, JSON.stringify(params, null, 2));
 }
 
 export function buttonPage(page: number, max: number, button: helper.bottypes.buttonType) {

--- a/src/tools/data.ts
+++ b/src/tools/data.ts
@@ -160,7 +160,7 @@ const cacheById = [
 export function storeFile(data: any, id: string | number, name: string, mode?: osuapi.types_v2.GameMode, type?: string) {
     mode = other.modeValidator(mode);
     try {
-        let path = `${helper.path.main}/cache/commandData/`;
+        let path = `${helper.path.cache}/commandData/`;
         if (cacheById.some(x => name.includes(x))) {
             switch (true) {
                 case (name.includes('mapdata')): {

--- a/src/tools/formatters.ts
+++ b/src/tools/formatters.ts
@@ -369,7 +369,7 @@ export class ScoreFormatter {
         const scoreStat = `\`${calculate.numberShorthand(other.getTotalScore(score))}\``;
         const str: string[] = [rank, scoreStat];
         if (score?.beatmap?.difficulty_rating) {
-            const stars = `${score?.beatmap?.difficulty_rating?.toFixed(2)}⭐`;
+            const stars = `${calculate.fixLongDecimal(score?.beatmap?.difficulty_rating)}⭐`;
             str.push(stars);
         }
         if (score.mods.length > 0 && this.preset != 'single_map') {
@@ -406,7 +406,7 @@ export class ScoreFormatter {
             const removedMsg = `**Removed ${rm}❌**\n`;
             const hits = returnHits(score.statistics, score.ruleset_id).short;
             const combo = `**${perfs[1].difficulty.maxCombo}x**`;
-            const accuracy = `${(score.accuracy * 100).toFixed(2)}% ->  **${acc.toFixed(2)}%**`;
+            const accuracy = `${calculate.fixLongDecimal(score.accuracy * 100)}% ->  **${calculate.fixLongDecimal(acc)}%**`;
             str = [
                 removedMsg, hits, combo, accuracy
             ];
@@ -414,7 +414,7 @@ export class ScoreFormatter {
             const hits = returnHits(score.statistics, score.ruleset_id).short;
             let combo = `${score?.max_combo}/**${perfs[1].difficulty.maxCombo}x**`;
             if (score.max_combo == perfs[1].difficulty.maxCombo || !score.max_combo) combo = `**${score.max_combo}x**`;
-            const accuracy = `${(score.accuracy * 100).toFixed(2)}%`;
+            const accuracy = `${calculate.fixLongDecimal(score.accuracy * 100)}%`;
             str = [
                 hits, combo, accuracy
             ];
@@ -422,11 +422,11 @@ export class ScoreFormatter {
         return listLine(str);
     }
     scoreStatsPerformance(score: osuapi.types_v2.Score, perfs: PerformanceAttributes[]) {
-        let str = `${(score?.pp ?? perfs[0].pp).toFixed(2)}pp`;
+        let str = `${calculate.fixLongDecimal(score?.pp ?? perfs[0].pp)}pp`;
         if (!score?.is_perfect_combo) {
-            str += ' (' + perfs[1].pp.toFixed(2) + 'pp if FC)';
+            str += ' (' + calculate.fixLongDecimal(perfs[1].pp) + 'pp if FC)';
         } else if (score?.accuracy < 1) {
-            str += ' (' + perfs[2].pp.toFixed(2) + 'pp if SS)';
+            str += ' (' + calculate.fixLongDecimal(perfs[2].pp) + 'pp if SS)';
         }
         return str;
     }

--- a/src/tools/graph.ts
+++ b/src/tools/graph.ts
@@ -240,7 +240,7 @@ export abstract class GraphBuilder {
     }
     protected async toFile() {
         const filename = `${(new Date).getTime()}`;
-        let curt = `${helper.path.main}/cache/graphs/${filename}.jpg`;
+        let curt = `${helper.path.cache}/graphs/${filename}.jpg`;
         try {
             const buffer = await this.toBuffer();
             fs.writeFileSync(curt, buffer);
@@ -795,7 +795,7 @@ export class OldGraphBuilder {
     }
     async writeToFile() {
         const filename = `${(new Date).getTime()}`;
-        let curt = `${helper.path.main}/cache/graphs/${filename}.jpg`;
+        let curt = `${helper.path.cache}/graphs/${filename}.jpg`;
         try {
             const buffer = await this.graphBuffer();
             fs.writeFileSync(curt, buffer);

--- a/src/tools/other.ts
+++ b/src/tools/other.ts
@@ -519,3 +519,11 @@ export function dataIsEmpty(value: any, disallowNull = true, disallowNaN = true,
 export function isSet(value: any) {
     return (value != null && value != undefined);
 }
+
+export function repeatArray<T extends any>(data: T, count: number): T[] {
+    const temp: T[] = [];
+    for (let i = 0; i < count; i++) {
+        temp.push(data);
+    }
+    return temp;
+}

--- a/src/tools/other.ts
+++ b/src/tools/other.ts
@@ -25,17 +25,17 @@ export function appendUrlParamsString(url: string, params: string[]) {
 
 export function debug(data: any, type: string, name: string, serverId: string | number, params: string) {
     const pars = params.replaceAll(',', '=');
-    if (!fs.existsSync(`${helper.path.main}/cache/debug/${type}`)) {
-        fs.mkdirSync(`${helper.path.main}/cache/debug/${type}`);
+    if (!fs.existsSync(`${helper.path.cache}/debug/${type}`)) {
+        fs.mkdirSync(`${helper.path.cache}/debug/${type}`);
     }
-    if (!fs.existsSync(`${helper.path.main}/cache/debug/${type}/${name}/`)) {
-        fs.mkdirSync(`${helper.path.main}/cache/debug/${type}/${name}`);
+    if (!fs.existsSync(`${helper.path.cache}/debug/${type}/${name}/`)) {
+        fs.mkdirSync(`${helper.path.cache}/debug/${type}/${name}`);
     }
     try {
         if (data?.input?.config) {
             data.helper.vars.config = censorConfig();
         }
-        fs.writeFileSync(`${helper.path.main}/cache/debug/${type}/${name}/${pars}_${serverId}.json`, JSON.stringify(data, null, 2));
+        fs.writeFileSync(`${helper.path.cache}/debug/${type}/${name}/${pars}_${serverId}.json`, JSON.stringify(data, null, 2));
     } catch (error) {
     }
     return;

--- a/src/tools/track.ts
+++ b/src/tools/track.ts
@@ -151,7 +151,7 @@ export async function getEmbed(
     const mxCombo = perf.difficulty.maxCombo;
     const usepp = data.scoredata.pp ?? perf.pp;
     if (data.scoredata.accuracy != 1) {
-        pp = `${usepp}pp ${data.scoredata.max_combo == mxCombo ? '(FC)' : `(${fcperf.pp.toFixed(2)} if FC)`}`;
+        pp = `${usepp}pp ${data.scoredata.max_combo == mxCombo ? '(FC)' : `(${calculate.fixLongDecimal(fcperf.pp)} if FC)`}`;
     } else {
         pp = `${usepp}pp (SS)`;
     }
@@ -168,7 +168,7 @@ export async function getEmbed(
         .setImage(`${data.scoredata.beatmapset.covers['cover@2x']}`)
         .setDescription(
             `${data.scoredata.mods.length > 0 ? '+' + data.scoredata.mods.map(x => x.acronym).join('') + ' | ' : ''} **Score set** <t:${new Date(data.scoredata.ended_at).getTime() / 1000}:R>\n` +
-            `${(data.scoredata.accuracy * 100).toFixed(2)}% | ${formatters.gradeToEmoji(data.scoredata.rank)} | ${(perf.difficulty.stars ?? data.scoredata.beatmap.difficulty_rating).toFixed(2)}⭐\n` +
+            `${calculate.fixLongDecimal(data.scoredata.accuracy * 100)}% | ${formatters.gradeToEmoji(data.scoredata.rank)} | ${calculate.fixLongDecimal(perf.difficulty.stars ?? data.scoredata.beatmap.difficulty_rating)}⭐\n` +
             `${formatters.returnHits(data.scoredata.statistics, data.scoredata.ruleset_id).short} | ${data.scoredata.max_combo}x\n` +
             `${pp}`
         );

--- a/src/vars/commandData.ts
+++ b/src/vars/commandData.ts
@@ -4,15 +4,15 @@ import * as buttonsObjs from './buttons';
 
 const mods = 'See [here](https://ssob.sbrstrkkdwmdr.me/types#mods)';
 const scoreListString =
-    `Mods can be specified with +[mods], -mx [exact mods] or -me [exclude mods]
+    `Mods can be specified with \`+[mods]\`, \`-mx [exact mods]\` or \`-me [exclude mods]\`
 The arguments \`pp\`, \`score\`, \`acc\`, \`bpm\` and \`miss\` use the following format:
 \`-key value\` to filter by that exact value (eg. \`-bpm 220\`)
 \`-key >value\` to filter scores above that value (eg. \`-pp >500\`)
 \`-key <value\` to filter scores below that value (eg. \`-acc <90\`)
-\`-key min..max\` to filter scores between min and max (eg. \`-miss 1..3\`)
+\`-key min..max\` to filter scores within a range (eg. \`-miss 1..3\`)
 \`-key !value\` to filter scores that dont equal that value (eg. \`-bpm !200\`)
 The \`sort\` arg can be specified using \`-value\` (ie \`-recent\`)
-You can also show a single score by using \`-parse <id>\` (eg. \`-parse 5\`)
+You can also show a single score by using \`-parse <index>\` (eg. \`-parse 5\`)
 `;
 
 const range = (key: string): string[] => {

--- a/src/vars/versions.ts
+++ b/src/vars/versions.ts
@@ -1,6 +1,6 @@
-export const releaseDate = '20251218';
+export const releaseDate = '20260125';
 
-export const current = '5.6.0';
+export const current = '5.6.1';
 
 export const versions: {
     name: string,
@@ -9,6 +9,10 @@ export const versions: {
         { // keep this 
             name: 'WIP',
             releaseDate: 'xxxx-xx-xx'
+        },
+        {
+            name: '5.6.1',
+            releaseDate: '2026-01-25'
         },
         {
             name: '5.6.0',

--- a/src/web.ts
+++ b/src/web.ts
@@ -39,7 +39,7 @@ export function begin() {
         });
     });
     app.get('/changelog', (req, res, next) => {
-        const doc = readFileSync(`${helper.path.main}/cache/changelog.md`, 'utf-8');
+        const doc = readFileSync(`${helper.path.cache}/changelog.md`, 'utf-8');
         res.render('changelog', {
             layout: 'layout',
             title: 'Changelog',

--- a/todo.md
+++ b/todo.md
@@ -4,6 +4,8 @@ newest-oldest
 
 ## current
 
+- [ ] `Simulate` `-prev` doesn't handle custom speed properly
+- [x] `Simulate` `-speed` arg should override DT instead of multiplying them together
 - [x] `Recent` highlight section passed on map strains if score is fail
 - [x] graphs: disable ticks on strains graph
 - [x] option to disable grid and legends

--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@ newest-oldest
 
 ## current
 
-- [ ] `Simulate` `-prev` doesn't handle custom speed properly
+- [x] `Simulate` `-prev` doesn't handle custom speed properly
 - [x] `Simulate` `-speed` arg should override DT instead of multiplying them together
 - [x] `Recent` highlight section passed on map strains if score is fail
 - [x] graphs: disable ticks on strains graph


### PR DESCRIPTION
### Fixed

-   `MapParse` - Submitted not being on a new line
-   `MapParse` - Mirror names
-   `WhatIf` - command not properly quitting if a null value is given
-   `Simulate` - DT/NC/HT/DC no longer multiplies `overrideSpeed`
-   `Simulate` - custom speed from previous scores is ignored
-   `MapParse` - ppcalc embed not being sent

### Changed

-   (docs) small tweaks
-   sendError() no longer throws an error (mostly just cluttered the console)
-   only use `.toFixed()` on numbers that exceed 2 d.p.